### PR TITLE
Set no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 //! This crate provides the [`naked`] proc macro.
+#![no_std]
 
 #[doc(inline)]
 pub use naked_function_macro::naked;


### PR DESCRIPTION
Add the `#![no_std]` attribute to the main crate. This allows the use of `naked_function` in no_std builds. Previously would pull in std and would get duplicate definition errors for `#[panic_handler]` and `#[lang = "eh_personality"]`.

Setting the main crate to no_std will take advantage of Cargo's [version 2 feature unifier](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2) (bullet point 2) which will only pull in std for the proc macro crate.