### PR TITLE
Fix compile error on arm targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ cfg_if::cfg_if! {
         #[cfg(target_arch = "arm")]
         #[doc(hidden)]
         #[macro_export]
-        macro_rules! __asm_function_type {
+        macro_rules! __asm_type {
             ($ty:literal) => { concat!("%", $ty) }
         }
         #[doc(hidden)]


### PR DESCRIPTION
On arm targets (in my case, thumbv6m-none-eabi), compilation fails due to 

```
   |
14 |     #[naked_function::naked]
   |     ^^^^^^^^^^^^^^^^^^^^^^^^ could not find `__asm_type` in `$crate`
   |
   = note: this error originates in the macro `::naked_function::__asm_function_begin` which comes from the expansion of the attribute macro `naked_function::naked` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This resolves the compile error by updating the unused `__asm_function_type` macro to have the same name as the non-arm macro `__asm_type`.

Thumb targets should probably also have a `.thumb_func` directive, but I wasn't able to get it to generate above the label. Even by replacing `naked_function` with the equivalent `global_asm!` -- it was always placed after the label. According to the as documentation, `thumb_func` isn't necessary for eabi targets, so I left that for now.