### PR TITLE
Fix cfg names in test

### DIFF
--- a/tests/conditional.rs
+++ b/tests/conditional.rs
@@ -19,9 +19,11 @@ pub unsafe extern "C" fn ret() -> i32 {
 fn test_conditional() {
     let x = unsafe { ret() };
 
-    if cfg!(x86_64) {
-        debug_assert_eq!(x, 1);
-    } else if cfg!(aarch64) {
-        debug_assert_eq!(x, 2);
+    if cfg!(target_arch = "x86_64") {
+        assert_eq!(x, 1);
+    } else if cfg!(target_arch = "aarch64") {
+        assert_eq!(x, 2);
+    } else {
+        panic!();
     }
 }


### PR DESCRIPTION
https://github.com/Amanieu/naked-function/blob/b0461cab8cdb28ab447c1dc2dd5afad7520a22f4/tests/conditional.rs#L22-L24

Both cfg(x86_64) and cfg(aarch64) are not valid cfg names.

```console
# cfg(is_thumb) is set by build script.
$ RUSTFLAGS='-Z unstable-options --check-cfg=names(is_thumb)' cargo check -Z check-cfg=names --tests
warning: unexpected `cfg` condition name
  --> tests/conditional.rs:22:13
   |
22 |     if cfg!(x86_64) {
   |             ^^^^^^
   |
   = note: `#[warn(unexpected_cfgs)]` on by default

warning: unexpected `cfg` condition name
  --> tests/conditional.rs:24:20
   |
24 |     } else if cfg!(aarch64) {
   |                    ^^^^^^^
```

In fact, adding `else { panic!() }` to end of this if block will cause the test to fail.
